### PR TITLE
Web based query interface v2

### DIFF
--- a/cmd/ekanited/main.go
+++ b/cmd/ekanited/main.go
@@ -75,6 +75,7 @@ func main() {
 		caPemPath       = fs.String("tlspem", "", "path to CA PEM file for TLS-enabled TCP server. If not set, TLS not activated")
 		caKeyPath       = fs.String("tlskey", "", "path to CA key file for TLS-enabled TCP server. If not set, TLS not activated")
 		queryIface      = fs.String("query", DefaultQueryAddr, "TCP Bind address for query server in the form host:port. To disable set to empty string")
+		queryIfaceHttp  = fs.String("queryhttp", "", "TCP Bind address for http query server in the form host:port. To disable set to empty string")
 		numShards       = fs.Int("numshards", DefaultNumShards, "Set number of shards per index")
 		retentionPeriod = fs.String("retention", DefaultRetentionPeriod, "Data retention period. Minimum is 24 hours")
 		cpuProfile      = fs.String("cpuprof", "", "Where to write CPU profiling data. Not written if not set")
@@ -138,6 +139,18 @@ func main() {
 			log.Fatalf("failed to start query server: %s", err.Error())
 		}
 		log.Printf("query server listening to %s", *queryIface)
+	}
+
+	// Start the http query server if requested.
+	if *queryIfaceHttp != "" {
+		server := ekanite.NewHttpServer(*queryIfaceHttp, engine)
+		if server == nil {
+			log.Fatal("failed to create http query server")
+		}
+		if err := server.Start(); err != nil {
+			log.Fatalf("failed to start http query server: %s", err.Error())
+		}
+		log.Printf("http query server listening to %s", *queryIfaceHttp)
 	}
 
 	// Create and start the batcher.

--- a/cmd/ekanited/main.go
+++ b/cmd/ekanited/main.go
@@ -145,12 +145,12 @@ func main() {
 	if *queryIfaceHttp != "" {
 		server := ekanite.NewHttpServer(*queryIfaceHttp, engine)
 		if server == nil {
-			log.Fatal("failed to create http query server")
+			log.Fatal("failed to create HTTP query server")
 		}
 		if err := server.Start(); err != nil {
-			log.Fatalf("failed to start http query server: %s", err.Error())
+			log.Fatalf("failed to start HTTP query server: %s", err.Error())
 		}
-		log.Printf("http query server listening to %s", *queryIfaceHttp)
+		log.Printf("HTTP query server listening to %s", *queryIfaceHttp)
 	}
 
 	// Create and start the batcher.

--- a/cmd/ekanited/system_test.go
+++ b/cmd/ekanited/system_test.go
@@ -1,7 +1,6 @@
 package main_test
 
 import (
-	"bufio"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -320,42 +319,17 @@ func NewServer(addr string, e *testEngine) *testServer {
 }
 
 // Search performs the given search and returns the log lines in a slice.
-func (s *testServer) Search(query string) ([]string, error) {
-	conn, err := net.Dial("tcp", s.Addr().String())
+func (s *testServer) Search(query string) (resultSlice []string, err error) {
+	resultSet, err := s.Searcher.Search(query)
+
 	if err != nil {
-		panic("unable to connect to query server")
-	}
-
-	n, err := conn.Write([]byte(query + "\n"))
-	if err != nil {
-		return nil, err
-	}
-	if n != len(query)+1 {
-		return nil, fmt.Errorf("incorrect number of bytes written to query server, exp: %d, wrote: %d", len(query)+1, n)
-	}
-
-	var firstNewline bool
-	results := make([]string, 0)
-	connbuf := bufio.NewReader(conn)
-	for {
-		result, err := connbuf.ReadString('\n')
-		if err != nil {
-			return nil, err
+		return
+	} else {
+		for v := range resultSet {
+			resultSlice = append(resultSlice, v)
 		}
-		if result == "\n" {
-			if firstNewline {
-				// No more results.
-				break
-			}
-			firstNewline = true
-			continue
-		} else {
-			firstNewline = false
-		}
-		results = append(results, strings.Trim(result, "\n"))
 	}
-
-	return results, nil
+	return
 }
 
 type testCollector struct {

--- a/server.go
+++ b/server.go
@@ -15,7 +15,7 @@ type Searcher interface {
 // Server serves query client connections.
 type Server struct {
 	iface    string
-	searcher Searcher
+	Searcher Searcher
 
 	addr net.Addr
 
@@ -26,7 +26,7 @@ type Server struct {
 func NewServer(iface string, searcher Searcher) *Server {
 	return &Server{
 		iface:    iface,
-		searcher: searcher,
+		Searcher: searcher,
 		Logger:   log.New(os.Stderr, "[server] ", log.LstdFlags),
 	}
 }
@@ -78,7 +78,7 @@ func (s *Server) handleConnection(conn net.Conn) {
 			}
 
 			s.Logger.Printf("executing query '%s'", query)
-			c, err := s.searcher.Search(query)
+			c, err := s.Searcher.Search(query)
 			if err != nil {
 				conn.Write([]byte(err.Error()))
 			} else {

--- a/server_http.go
+++ b/server_http.go
@@ -92,10 +92,10 @@ func (s *HttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			s.Logger.Printf("Error executing query: '%s'", err)
 			http.Error(w, "Error executing query: "+err.Error(), http.StatusInternalServerError)
 			return
-		} else {
-			for s := range resultSet {
-				resultSlice = append(resultSlice, s)
-			}
+		}
+
+		for s := range resultSet {
+			resultSlice = append(resultSlice, s)
 		}
 
 		data := struct {

--- a/server_http.go
+++ b/server_http.go
@@ -35,7 +35,6 @@ func NewHttpServer(iface string, searcher Searcher) *HttpServer {
 
 // Start instructs the Server to bind to the interface and accept connections.
 func (s *HttpServer) Start() error {
-
 	ln, err := net.Listen("tcp", s.iface)
 	if err != nil {
 		return err
@@ -64,15 +63,12 @@ func (s *HttpServer) Addr() net.Addr {
 
 // ServeHTTP implements a http.Handler, serving the query interface for Ekanite
 func (s *HttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-
 	dontCache(w, r)
 
 	if r.Method == "GET" || r.Method == "HEAD" {
-		//HEAD is conveniently supported by net/http without further action
+		// HEAD is conveniently supported by net/http without further action
 		serveIndex(s, w, r)
-
 	} else if r.Method == "POST" {
-
 		err := r.ParseForm()
 		if err != nil {
 			s.Logger.Printf("Error parsing form '%s'", err)
@@ -144,12 +140,10 @@ func serveIndex(s *HttpServer, w http.ResponseWriter, r *http.Request) {
 	if err := s.template.Execute(w, data); err != nil {
 		s.Logger.Print("Error executing template: ", err)
 	}
-
 }
 
 // dontCache sets necessary headers to avoid client and intermediate caching of response
 func dontCache(w http.ResponseWriter, r *http.Request) {
-
 	w.Header().Set("Expires", time.Unix(0, 0).Format(time.RFC1123))
 	w.Header().Set("Last-Modified", time.Now().Format(time.RFC1123))
 	w.Header().Set("Cache-Control", "private, no-store, max-age=0, no-cache, must-revalidate, post-check=0, pre-check=0")

--- a/server_http.go
+++ b/server_http.go
@@ -166,36 +166,36 @@ const templateSource string = `
 <meta charset="utf-8" />
 <title>{{ $.Title }}</title>
 <style type="text/css"> 
-body, h3 {
-margin: 50px;
-font-family: sans-serif;
-font-size: 13px;
+body, h2 {
+	margin: 50px;
+	font-family: sans-serif;
+	font-size: 13px;
 }
-h3 {
-font-size: 15px;
+h2 {
+	font-size: 15px;
 }
 .button {
-background: #3498db;
-background-image: linear-gradient(to bottom, #3498db, #2980b9);
-border-radius: 4px;
-font-family: sans-serif;
-color: #ffffff;
-font-size: 15px;
-padding: 10px 20px 10px 20px;
-margin-bottom: 20px;
-text-decoration: none;
+	background: #3498db;
+	background-image: linear-gradient(to bottom, #3498db, #2980b9);
+	border-radius: 4px;
+	font-family: sans-serif;
+	color: #ffffff;
+	font-size: 15px;
+	padding: 10px 20px 10px 20px;
+	margin-bottom: 20px;
+	text-decoration: none;
 }
 hr {
 	margin-bottom: 10px;
 	margin-top: 10px;
 }
 .button:hover {
-background: #3cb0fd;
-background-image: linear-gradient(to bottom, #3cb0fd, #3498db);
-text-decoration: none;
+	background: #3cb0fd;
+	background-image: linear-gradient(to bottom, #3cb0fd, #3498db);
+	text-decoration: none;
 }
 textarea {
-margin: 20px 20px 20px 0;
+	margin: 20px 20px 20px 0;
 }
 </style>
 </head>

--- a/server_http.go
+++ b/server_http.go
@@ -1,0 +1,220 @@
+package ekanite
+
+import (
+	"html/template"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/gorilla/csrf"
+	"github.com/gorilla/securecookie"
+)
+
+// Server serves query client connections.
+type HttpServer struct {
+	iface    string
+	Searcher Searcher
+
+	addr     net.Addr
+	template *template.Template
+
+	Logger *log.Logger
+}
+
+// NewServer returns a new Server instance.
+func NewHttpServer(iface string, searcher Searcher) *HttpServer {
+	return &HttpServer{
+		iface:    iface,
+		Searcher: searcher,
+		Logger:   log.New(os.Stderr, "[httpserver] ", log.LstdFlags),
+	}
+}
+
+// Start instructs the Server to bind to the interface and accept connections.
+func (s *HttpServer) Start() error {
+
+	ln, err := net.Listen("tcp", s.iface)
+	if err != nil {
+		return err
+	}
+
+	s.addr = ln.Addr()
+
+	s.template, err = template.New("ServerTemplate").Parse(templateSource)
+	if err != nil {
+		ln.Close()
+		return err
+	}
+
+	CSRF := csrf.Protect(securecookie.GenerateRandomKey(32),
+		csrf.Secure(false),
+		csrf.HttpOnly(true))
+
+	go http.Serve(ln, CSRF(s))
+	return nil
+}
+
+// Addr returns the address to which the Server is bound.
+func (s *HttpServer) Addr() net.Addr {
+	return s.addr
+}
+
+// ServeHTTP implements a http.Handler, serving the query interface for Ekanite
+func (s *HttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
+	dontCache(w, r)
+
+	if r.Method == "GET" || r.Method == "HEAD" {
+		//HEAD is conveniently supported by net/http without further action
+		serveIndex(s, w, r)
+
+	} else if r.Method == "POST" {
+
+		err := r.ParseForm()
+		if err != nil {
+			s.Logger.Printf("Error parsing form '%s'", err)
+			http.Error(w, "Error parsing form", http.StatusBadRequest)
+			return
+		}
+
+		if len(r.FormValue("query")) == 0 {
+			serveIndex(s, w, r)
+			return
+		}
+
+		userQuery := r.FormValue("query")
+
+		s.Logger.Printf("executing query '%s'", userQuery)
+
+		resultSet, err := s.Searcher.Search(userQuery)
+		var resultSlice []string
+
+		if err != nil {
+			s.Logger.Printf("Error executing query: '%s'", err)
+			http.Error(w, "Error executing query: "+err.Error(), http.StatusInternalServerError)
+			return
+		} else {
+			for s := range resultSet {
+				resultSlice = append(resultSlice, s)
+			}
+		}
+
+		data := struct {
+			Title         string
+			Headline      string
+			ReturnResults bool
+			LogMessages   []string
+			CsrfField     template.HTML
+		}{
+			"Ekanite query interface",
+			"Ekanite - Listing " + strconv.Itoa(len(resultSlice)) + " results for '" + userQuery + "'",
+			true,
+			resultSlice,
+			csrf.TemplateField(r),
+		}
+
+		if err := s.template.Execute(w, data); err != nil {
+			s.Logger.Print("Error executing template: ", err)
+		}
+
+	} else {
+		http.Error(w, "Unsupported method", http.StatusMethodNotAllowed)
+	}
+}
+
+// serveIndex serves the plain index for the GET request and POST failovers
+func serveIndex(s *HttpServer, w http.ResponseWriter, r *http.Request) {
+	data := struct {
+		Title         string
+		Headline      string
+		ReturnResults bool
+		LogMessages   []string
+		CsrfField     template.HTML
+	}{
+		"Ekanite query interface",
+		"Ekanite query interface",
+		false,
+		[]string{},
+		csrf.TemplateField(r),
+	}
+
+	if err := s.template.Execute(w, data); err != nil {
+		s.Logger.Print("Error executing template: ", err)
+	}
+
+}
+
+// dontCache sets necessary headers to avoid client and intermediate caching of response
+func dontCache(w http.ResponseWriter, r *http.Request) {
+
+	w.Header().Set("Expires", time.Unix(0, 0).Format(time.RFC1123))
+	w.Header().Set("Last-Modified", time.Now().Format(time.RFC1123))
+	w.Header().Set("Cache-Control", "private, no-store, max-age=0, no-cache, must-revalidate, post-check=0, pre-check=0")
+
+	return
+}
+
+const templateSource string = `
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>{{ $.Title }}</title>
+<style type="text/css"> 
+body, h3 {
+margin: 50px;
+font-family: sans-serif;
+font-size: 13px;
+}
+h3 {
+font-size: 15px;
+}
+.button {
+background: #3498db;
+background-image: linear-gradient(to bottom, #3498db, #2980b9);
+border-radius: 4px;
+font-family: sans-serif;
+color: #ffffff;
+font-size: 15px;
+padding: 10px 20px 10px 20px;
+margin-bottom: 20px;
+text-decoration: none;
+}
+hr {
+	margin-bottom: 10px;
+	margin-top: 10px;
+}
+.button:hover {
+background: #3cb0fd;
+background-image: linear-gradient(to bottom, #3cb0fd, #3498db);
+text-decoration: none;
+}
+textarea {
+margin: 20px 20px 20px 0;
+}
+</style>
+</head>
+<body>
+	<h2>{{ $.Headline }}</h2>
+	<div id="help">Query language reference: <a href="http://godoc.org/github.com/blevesearch/bleve#NewQueryStringQuery">bleve</a></div>
+	<form action="/" method="POST">
+    <textarea name="query" cols="100" rows="2"></textarea>
+    <br>
+    <input name="submit" type="submit" class="button" value="Query">
+    {{ .CsrfField }}
+	</form>
+	
+{{ if $.ReturnResults }}
+	<hr>
+	<ul>
+	{{range $message := $.LogMessages }}
+	<li>{{ $message }}</li>
+	{{ end }}
+	</ul>
+{{ end }}
+</body>
+</html>
+`


### PR DESCRIPTION
See #20 for original PR.

In this branch the telnet query server is not replaced, the simple http query server is added opt-in as suggested by @otoolep.
justinas/nosurf was replaced by gorilla/csrf for security reasons.

Tests are made independent from any user interface.

TLS protection and authentication is currently not handled by this code and should be done via e.g. nginx for production setups.
The CSRF base hmac key is dynamically regenerated on every startup (would ideally be persisted in configuration).
It is worth noting that if the complexity of the inlined template increases over time, it may be sensible to separate it into a proper template file at some point.

I couldn't yet test with real log data, however the core code is identical to my former PR and the query seems to be properly handed over to the engine.

Looking forward to your feedback! :smile: 