### PR TITLE
Introducing input format

### DIFF
--- a/cmd/ekanited/main.go
+++ b/cmd/ekanited/main.go
@@ -43,6 +43,7 @@ var numShards int
 var retentionPeriod string
 var cpuProfile string
 var memProfile string
+var inputFormat string
 
 // Flag set
 var fs *flag.FlagSet

--- a/cmd/ekanited/main.go
+++ b/cmd/ekanited/main.go
@@ -80,7 +80,7 @@ func main() {
 		retentionPeriod = fs.String("retention", DefaultRetentionPeriod, "Data retention period. Minimum is 24 hours")
 		cpuProfile      = fs.String("cpuprof", "", "Where to write CPU profiling data. Not written if not set")
 		memProfile      = fs.String("memprof", "", "Where to write memory profiling data. Not written if not set")
-		_               = fs.String("input", DefaultInputFormat, "Message format of input.")
+		inputFormat     = fs.String("input", DefaultInputFormat, "Message format of input.")
 	)
 	fs.Usage = printHelp
 	fs.Parse(os.Args[1:])
@@ -190,7 +190,7 @@ func main() {
 			log.Printf("TLS successfully configured")
 		}
 
-		collector := input.NewCollector("tcp", *tcpIface, tlsConfig)
+		collector := input.NewCollector("tcp", *tcpIface, tlsConfig, *inputFormat)
 		if collector == nil {
 			log.Fatalf("failed to created TCP collector bound to %s", *tcpIface)
 		}
@@ -202,7 +202,7 @@ func main() {
 
 	// Start UDP collector if requested.
 	if *udpIface != "" {
-		collector := input.NewCollector("udp", *udpIface, nil)
+		collector := input.NewCollector("udp", *udpIface, nil, *inputFormat)
 		if collector == nil {
 			log.Fatalf("failed to created UDP collector for to %s", *udpIface)
 		}

--- a/cmd/ekanited/main.go
+++ b/cmd/ekanited/main.go
@@ -59,6 +59,7 @@ const (
 	DefaultHTTPQueryAddr   = "localhost:8080"
 	DefaultDiagsIface      = "localhost:9951"
 	DefaultTCPServer       = "localhost:5514"
+	DefaultInputFormat     = "syslog"
 )
 
 func main() {
@@ -79,6 +80,7 @@ func main() {
 		retentionPeriod = fs.String("retention", DefaultRetentionPeriod, "Data retention period. Minimum is 24 hours")
 		cpuProfile      = fs.String("cpuprof", "", "Where to write CPU profiling data. Not written if not set")
 		memProfile      = fs.String("memprof", "", "Where to write memory profiling data. Not written if not set")
+		_               = fs.String("input", DefaultInputFormat, "Message format of input.")
 	)
 	fs.Usage = printHelp
 	fs.Parse(os.Args[1:])

--- a/cmd/ekanited/system_test.go
+++ b/cmd/ekanited/system_test.go
@@ -338,7 +338,7 @@ type testCollector struct {
 
 // NewCollector returns a new test TCP collector.
 func NewCollector(addr string) *testCollector {
-	return &testCollector{input.NewCollector("tcp", addr, nil)}
+	return &testCollector{input.NewCollector("tcp", addr, nil, "syslog")}
 }
 
 type testBatcher struct {

--- a/input/collector.go
+++ b/input/collector.go
@@ -32,6 +32,7 @@ type Collector interface {
 // TCPCollector represents a network collector that accepts and handler TCP connections.
 type TCPCollector struct {
 	iface  string
+	fmt    string
 	parser *RFC5424Parser
 
 	addr      net.Addr
@@ -41,17 +42,19 @@ type TCPCollector struct {
 // UDPCollector represents a network collector that accepts UDP packets.
 type UDPCollector struct {
 	addr   *net.UDPAddr
+	fmt    string
 	parser *RFC5424Parser
 }
 
 // NewCollector returns a network collector of the specified type, that will bind
 // to the given inteface on Start(). If config is non-nil, a secure Collector will
 // be returned. Secure Collectors require the protocol be TCP.
-func NewCollector(proto, iface string, tlsConfig *tls.Config) Collector {
+func NewCollector(proto, iface string, tlsConfig *tls.Config, format string) Collector {
 	parser := NewRFC5424Parser()
 	if strings.ToLower(proto) == "tcp" {
 		return &TCPCollector{
 			iface:     iface,
+			fmt:       format,
 			parser:    parser,
 			tlsConfig: tlsConfig,
 		}
@@ -61,7 +64,7 @@ func NewCollector(proto, iface string, tlsConfig *tls.Config) Collector {
 			return nil
 		}
 
-		return &UDPCollector{addr: addr, parser: parser}
+		return &UDPCollector{addr: addr, fmt: format, parser: parser}
 	}
 	return nil
 }


### PR DESCRIPTION
As discussed in #25, this is the first pull request towards `ecma404` ([json](http://json.org/)) format support for the input of messages, as well as a restructuring of the [input server](https://github.com/ekanite/ekanite/tree/v1.0.0/input).

I mainly used a new flag named `input` which will serve the value of the user intended message format of  the input.