### PR TITLE
Improving the Delimiter

### DIFF
--- a/input/collector.go
+++ b/input/collector.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/ekanite/ekanite/input/delimiter"
 )
 
 var sequenceNumber int64
@@ -32,9 +34,14 @@ type Collector interface {
 
 // TCPCollector represents a network collector that accepts and handler TCP connections.
 type TCPCollector struct {
-	iface  string
-	fmt    string
-	parser *RFC5424Parser
+	iface        string
+	channel      chan<- *Event
+	conn         net.Conn
+	fmt          string
+	parser       *RFC5424Parser
+	delimiter    *delimiter.Delimiter
+	fDelimiter   *delimiter.FallbackDelimiter
+	fallbackMode bool
 
 	addr      net.Addr
 	tlsConfig *tls.Config
@@ -51,17 +58,18 @@ type UDPCollector struct {
 // to the given inteface on Start(). If config is non-nil, a secure Collector will
 // be returned. Secure Collectors require the protocol be TCP.
 func NewCollector(proto, iface, format string, tlsConfig *tls.Config) (Collector, error) {
-	parser := NewRFC5424Parser()
 	if format != "syslog" {
 		return nil, fmt.Errorf("unsupported collector format")
 	}
-
 	if strings.ToLower(proto) == "tcp" {
 		return &TCPCollector{
-			iface:     iface,
-			fmt:       format,
-			parser:    parser,
-			tlsConfig: tlsConfig,
+			iface:        iface,
+			fmt:          format,
+			parser:       NewRFC5424Parser(),
+			delimiter:    delimiter.NewDelimiter(),
+			fDelimiter:   delimiter.NewFallbackDelimiter(msgBufSize),
+			tlsConfig:    tlsConfig,
+			fallbackMode: false,
 		}, nil
 	} else if strings.ToLower(proto) == "udp" {
 		addr, err := net.ResolveUDPAddr("udp", iface)
@@ -69,7 +77,7 @@ func NewCollector(proto, iface, format string, tlsConfig *tls.Config) (Collector
 			return nil, err
 		}
 
-		return &UDPCollector{addr: addr, fmt: format, parser: parser}, nil
+		return &UDPCollector{addr: addr, fmt: format, parser: NewRFC5424Parser()}, nil
 	}
 	return nil, fmt.Errorf("unsupport collector protocol")
 }
@@ -108,45 +116,95 @@ func (s *TCPCollector) Addr() net.Addr {
 
 func (s *TCPCollector) handleConnection(conn net.Conn, c chan<- *Event) {
 	stats.Add("tcpConnections", 1)
+	s.conn = conn
+	s.channel = c
 	defer func() {
 		stats.Add("tcpConnections", -1)
-		conn.Close()
+		s.conn.Close()
 	}()
-
-	delimiter := NewDelimiter(msgBufSize)
 	reader := bufio.NewReader(conn)
-	var log string
-	var match bool
-
 	for {
 		conn.SetReadDeadline(time.Now().Add(newlineTimeout))
 		b, err := reader.ReadByte()
 		if err != nil {
 			stats.Add("tcpConnReadError", 1)
-			if neterr, ok := err.(net.Error); ok && neterr.Timeout() {
-				stats.Add("tcpConnReadTimeout", 1)
-				log, match = delimiter.Vestige()
-			} else if err == io.EOF {
-				stats.Add("tcpConnReadEOF", 1)
-				log, match = delimiter.Vestige()
-			} else {
-				stats.Add("tcpConnUnrecoverError", 1)
+			if !s.recover(err) {
 				return
 			}
 		} else {
 			stats.Add("tcpBytesRead", 1)
-			log, match = delimiter.Push(b)
-		}
-		if match {
-			stats.Add("tcpEventsRx", 1)
-			c <- &Event{
-				Text:          log,
-				Parsed:        s.parser.Parse(log),
-				ReceptionTime: time.Now().UTC(),
-				Sequence:      atomic.AddInt64(&sequenceNumber, 1),
-				SourceIP:      conn.RemoteAddr().String(),
+			if s.fallbackMode {
+				s.useFallbackDelimiter(b)
+			} else {
+				s.useDelimiter(b)
 			}
 		}
+	}
+}
+
+// Takes use of the standard delimiter
+// and switches to the fallback delimiter in case
+// of occuring errors.
+func (s *TCPCollector) useDelimiter(b byte) {
+	match, err := s.delimiter.Push(b)
+	if err != nil {
+		s.fallbackMode = true
+		s.delimiter.Reset()
+		if s.delimiter.Result != "" {
+			for i := 0; i < len(s.delimiter.Result); i++ {
+				s.useFallbackDelimiter(s.delimiter.Result[i])
+			}
+		} else {
+			s.useFallbackDelimiter(b)
+		}
+	}
+	if match {
+		stats.Add("tcpEventsRx", 1)
+		s.forwardLog(s.delimiter.Result)
+	}
+}
+
+// Takes use of the fallback delimiter.
+func (s *TCPCollector) useFallbackDelimiter(b byte) {
+	log, match := s.fDelimiter.Push(b)
+	if match {
+		stats.Add("tcpEventsRx", 1)
+		s.forwardLog(log)
+	}
+}
+
+// Tries to revover from occuring network errors.
+func (s *TCPCollector) recover(err error) bool {
+	if neterr, ok := err.(net.Error); ok && neterr.Timeout() {
+		stats.Add("tcpConnReadTimeout", 1)
+	} else if err == io.EOF {
+		stats.Add("tcpConnReadEOF", 1)
+	} else {
+		stats.Add("tcpConnUnrecoverError", 1)
+		return false
+	}
+	if !s.fallbackMode {
+		s.delimiter.Reset()
+		for i := 0; i < len(s.delimiter.Result); i++ {
+			s.useFallbackDelimiter(s.delimiter.Result[i])
+		}
+	} else {
+		log, match := s.fDelimiter.Vestige()
+		if match {
+			s.forwardLog(log)
+		}
+	}
+	return true
+}
+
+// Sends the parsed log via the provided channel.
+func (s *TCPCollector) forwardLog(log string) {
+	s.channel <- &Event{
+		Text:          log,
+		Parsed:        s.parser.Parse(log),
+		ReceptionTime: time.Now().UTC(),
+		Sequence:      atomic.AddInt64(&sequenceNumber, 1),
+		SourceIP:      s.conn.RemoteAddr().String(),
 	}
 }
 

--- a/input/delimiter/delimiter.go
+++ b/input/delimiter/delimiter.go
@@ -1,0 +1,116 @@
+package delimiter
+
+import (
+	"bytes"
+	"errors"
+	"strconv"
+)
+
+const (
+	LenBuffEnd = ":"
+	ValBuffEnd = ";"
+	NoResult   = false
+)
+
+var (
+	err error
+)
+
+// A Delimiter detects when message lines start.
+type Delimiter struct {
+	Result      string
+	lenBuff     bytes.Buffer
+	valBuff     bytes.Buffer
+	valBuffLen  int
+	valBuffMode bool
+	ignoreMode  bool
+	brokenMode  bool
+}
+
+// NewDelimiter returns an initialized Delimiter.
+func NewDelimiter() *Delimiter {
+	return &Delimiter{
+		lenBuff: *bytes.NewBuffer([]byte{}),
+		valBuff: *bytes.NewBuffer([]byte{}),
+	}
+}
+
+// Returns rather a new result is available
+// and the first occurring error (if any occurred).
+func (d *Delimiter) Push(b byte) (bool, error) {
+	if d.brokenMode {
+		return NoResult, errors.New("broken")
+	}
+	return d.processByte(b)
+}
+
+// Restes the instance close to its initial state.
+func (d *Delimiter) Reset() {
+	d.useLenBuff()
+}
+
+// Checks rather a byte must be processed as "length byte"
+// or as "value byte".
+func (d *Delimiter) processByte(b byte) (bool, error) {
+	if d.valBuffMode {
+		return d.processValByte(b)
+	}
+	return d.processLenByte(b)
+}
+
+// Writes the passed byte to the "length buffer",
+// unless the passed byte is the end of the "length buffer".
+func (d *Delimiter) processLenByte(b byte) (bool, error) {
+	if b == LenBuffEnd[0] {
+		return NoResult, d.useValBuff()
+	}
+	if err = d.lenBuff.WriteByte(b); err != nil {
+		d.brokenMode = true
+		return NoResult, errors.New("length-buffer-incomplete")
+	}
+	return NoResult, nil
+}
+
+// Writes the passed byte to the "value buffer",
+// unless the "value buffer length" is equal to 0.
+func (d *Delimiter) processValByte(b byte) (bool, error) {
+	if d.valBuffLen == 0 {
+		d.useLenBuff()
+		return true, nil
+	}
+	d.valBuffLen--
+	if d.ignoreMode {
+		return NoResult, nil
+	}
+	// If an error occurs, while writing to the buffer,
+	// the current "value buffer" gets ignored.
+	if err = d.valBuff.WriteByte(b); err != nil {
+		d.ignoreMode = true
+		return NoResult, errors.New("value-buffer-incomplete")
+	}
+	return NoResult, nil
+}
+
+// Overwrites the old result and resets values.
+func (d *Delimiter) useLenBuff() {
+	if d.ignoreMode {
+		d.Result = ""
+		d.ignoreMode = false
+	} else {
+		d.Result = d.valBuff.String()
+	}
+	d.valBuff.Reset()
+	d.valBuffMode = false
+}
+
+// Converts the "length buffer" value to an integer,
+// representing the "value buffer length" and resets values.
+func (d *Delimiter) useValBuff() error {
+	if d.valBuffLen, err = strconv.Atoi(d.lenBuff.String()); err != nil {
+		d.brokenMode = true
+		return errors.New("length-buffer-conversion-error")
+	}
+	d.lenBuff.Reset()
+	d.valBuffMode = true
+	return nil
+}

--- a/input/delimiter/delimiter.go
+++ b/input/delimiter/delimiter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"strconv"
+	"sync"
 )
 
 const (
@@ -14,11 +15,12 @@ const (
 
 var (
 	err        error
-	brokenErr  = errors.New("broken")
-	lenIncErr  = errors.New("length-buffer-incomplete")
-	lenInvErr  = errors.New("length-buffer-invalid-byte")
-	lenConvErr = errors.New("length-buffer-conversion-error")
-	valIncErr  = errors.New("value-buffer-incomplete")
+	mutex      *sync.Mutex = &sync.Mutex{}
+	brokenErr              = errors.New("broken")
+	lenIncErr              = errors.New("length-buffer-incomplete")
+	lenInvErr              = errors.New("length-buffer-invalid-byte")
+	lenConvErr             = errors.New("length-buffer-conversion-error")
+	valIncErr              = errors.New("value-buffer-incomplete")
 )
 
 // A Delimiter detects when message lines start.
@@ -51,7 +53,9 @@ func (d *Delimiter) Push(b byte) (bool, error) {
 
 // Resets the instance close to its initial state.
 func (d *Delimiter) Reset() {
+	mutex.Lock()
 	d.useLenBuff()
+	mutex.Unlock()
 }
 
 // Checks rather a byte must be processed as "length byte"

--- a/input/delimiter/delimiter_test.go
+++ b/input/delimiter/delimiter_test.go
@@ -29,14 +29,16 @@ var tests TestCases = TestCases{
 	},
 	"invalid length": TestCase{
 		raw:    "19a:bc",
-		errors: []string{"length-buffer-conversion-error", "broken", "broken"},
+		errors: []string{"length-buffer-invalid-byte", "broken", "broken", "broken"},
 	},
 	"missing length": TestCase{
-		raw: "I...",
+		raw:    "I...",
+		errors: []string{"length-buffer-invalid-byte", "broken", "broken", "broken"},
 	},
 	"missing semicolon": TestCase{
-		raw:     "19:I am a test string.30:And this is a test string too!",
+		raw:     "19:I am a test string.30:A...",
 		results: []string{"I am a test string.", ""},
+		errors:  []string{"length-buffer-invalid-byte", "broken", "broken"},
 	},
 	"length too short": TestCase{
 		raw:      "18:I am a test string.30:A",
@@ -60,6 +62,7 @@ var tests TestCases = TestCases{
 	},
 }
 
+// Test_Delimiter checks, rather each .Push call returns the expected.
 func Test_Delimiter(t *testing.T) {
 	for n, tc := range tests {
 		tc.delimiter = NewDelimiter()
@@ -98,8 +101,9 @@ func (tc *TestCase) checkMissingResults(t *testing.T) {
 }
 
 func (tc *TestCase) checkErr(err error, t *testing.T) {
-	if tc.errors == nil {
+	if len(tc.errors)-1 < tc.errorsIndex {
 		t.Errorf("\ndelimiter returned unexpected error: '%v'\n", err)
+		return
 	}
 	if tc.errors[tc.errorsIndex] != err.Error() {
 		t.Errorf("\nexpected error: %v (index: %d)\nreturned error: %v\n", tc.errors[tc.errorsIndex], tc.errorsIndex, err.Error())

--- a/input/delimiter/delimiter_test.go
+++ b/input/delimiter/delimiter_test.go
@@ -1,0 +1,120 @@
+package delimiter
+
+import (
+	"bytes"
+	"testing"
+)
+
+type TestCases map[string]TestCase
+
+type TestCase struct {
+	delimiter    *Delimiter
+	raw          string
+	results      []string
+	resultsIndex int
+	errors       []string
+	errorsIndex  int
+	leftover     string
+}
+
+var tests TestCases = TestCases{
+	"valid": TestCase{
+		raw: "19:I am a test string.;30:And this is a test string too!;29:You could add plenty of them.;31:And they should all work; fine.;",
+		results: []string{
+			"I am a test string.",
+			"And this is a test string too!",
+			"You could add plenty of them.",
+			"And they should all work; fine.",
+		},
+	},
+	"invalid length": TestCase{
+		raw:    "19a:bc",
+		errors: []string{"length-buffer-conversion-error", "broken", "broken"},
+	},
+	"missing length": TestCase{
+		raw: "I...",
+	},
+	"missing semicolon": TestCase{
+		raw:     "19:I am a test string.30:And this is a test string too!",
+		results: []string{"I am a test string.", ""},
+	},
+	"length too short": TestCase{
+		raw:      "18:I am a test string.30:A",
+		results:  []string{"I am a test string"},
+		leftover: "A",
+	},
+	"length too long": TestCase{
+		raw:     "20:I am a test string.30:A",
+		results: []string{"I am a test string.3"},
+		errors:  []string{"length-buffer-conversion-error", "broken"},
+	},
+	"value too short": TestCase{
+		raw:     "19:I am a test string30:A",
+		results: []string{"I am a test string3"},
+		errors:  []string{"length-buffer-conversion-error", "broken"},
+	},
+	"value too long": TestCase{
+		raw:      "19:I am a test string..30:A",
+		results:  []string{"I am a test string."},
+		leftover: "A",
+	},
+}
+
+func Test_Delimiter(t *testing.T) {
+	for n, tc := range tests {
+		tc.delimiter = NewDelimiter()
+		t.Logf("testing: %v\n", n)
+		buff := bytes.NewBufferString(tc.raw)
+		for _, b := range buff.Bytes() {
+			ok, err := tc.delimiter.Push(b)
+			if ok {
+				tc.checkResult(t)
+				tc.resultsIndex++
+			}
+			if err != nil {
+				tc.checkErr(err, t)
+				tc.errorsIndex++
+			}
+		}
+		tc.checkMissingResults(t)
+		tc.checkMissingErrors(t)
+		tc.checkLeftover(t)
+	}
+}
+
+func (tc *TestCase) checkResult(t *testing.T) {
+	if tc.results == nil {
+		t.Errorf("\ndelimiter returned unexpected result: '%v'\n", tc.delimiter.Result)
+	}
+	if tc.results[tc.resultsIndex] != tc.delimiter.Result {
+		t.Errorf("\nexpected result: %v (index: %d)\nreturned result:%v\n", tc.results[tc.resultsIndex], tc.resultsIndex, tc.delimiter.Result)
+	}
+}
+
+func (tc *TestCase) checkMissingResults(t *testing.T) {
+	if len(tc.results) != tc.resultsIndex {
+		t.Errorf("\ndelimiter missed some expected results: %v\n", tc.results[tc.resultsIndex:])
+	}
+}
+
+func (tc *TestCase) checkErr(err error, t *testing.T) {
+	if tc.errors == nil {
+		t.Errorf("\ndelimiter returned unexpected error: '%v'\n", err)
+	}
+	if tc.errors[tc.errorsIndex] != err.Error() {
+		t.Errorf("\nexpected error: %v (index: %d)\nreturned error: %v\n", tc.errors[tc.errorsIndex], tc.errorsIndex, err.Error())
+	}
+}
+
+func (tc *TestCase) checkMissingErrors(t *testing.T) {
+	if len(tc.errors) != tc.errorsIndex {
+		t.Errorf("\ndelimiter missed some expected errors: %v\n", tc.errors[tc.errorsIndex:])
+	}
+}
+
+func (tc *TestCase) checkLeftover(t *testing.T) {
+	tc.delimiter.Reset()
+	if tc.delimiter.Result != tc.leftover {
+		t.Errorf("\nexpected leftover: %v\nreturned leftover: %v\n", tc.leftover, tc.delimiter.Result)
+	}
+}

--- a/input/delimiter/fallback_delimiter.go
+++ b/input/delimiter/fallback_delimiter.go
@@ -1,4 +1,4 @@
-package input
+package delimiter
 
 import (
 	"regexp"
@@ -19,23 +19,23 @@ func init() {
 	runRegex = regexp.MustCompile(`\n` + SYSLOG_DELIMITER)
 }
 
-// A Delimiter detects when Syslog lines start.
-type Delimiter struct {
+// A FallbackDelimiter detects when Syslog lines start.
+type FallbackDelimiter struct {
 	buffer []byte
 	regex  *regexp.Regexp
 }
 
-// NewDelimiter returns an initialized Delimiter.
-func NewDelimiter(maxSize int) *Delimiter {
-	self := &Delimiter{}
+// NewFallbackDelimiter returns an initialized FallbackDelimiter.
+func NewFallbackDelimiter(maxSize int) *FallbackDelimiter {
+	self := &FallbackDelimiter{}
 	self.buffer = make([]byte, 0, maxSize)
 	self.regex = startRegex
 	return self
 }
 
-// Push a byte into the Delimiter. If the byte results in a
+// Push a byte into the FallbackDelimiter. If the byte results in a
 // a new Syslog message, it'll be flagged via the bool.
-func (self *Delimiter) Push(b byte) (string, bool) {
+func (self *FallbackDelimiter) Push(b byte) (string, bool) {
 	self.buffer = append(self.buffer, b)
 	delimiter := self.regex.FindIndex(self.buffer)
 	if delimiter == nil {
@@ -55,10 +55,10 @@ func (self *Delimiter) Push(b byte) (string, bool) {
 	return dispatch, true
 }
 
-// Vestige returns the bytes which have been pushed to Delimiter, since
+// Vestige returns the bytes which have been pushed to FallbackDelimiter, since
 // the last Syslog message was returned, but only if the buffer appears
 // to be a valid syslog message.
-func (self *Delimiter) Vestige() (string, bool) {
+func (self *FallbackDelimiter) Vestige() (string, bool) {
 	delimiter := syslogRegex.FindIndex(self.buffer)
 	if delimiter == nil {
 		self.buffer = nil

--- a/input/delimiter/fallback_delimiter_test.go
+++ b/input/delimiter/fallback_delimiter_test.go
@@ -1,14 +1,14 @@
-package input
+package delimiter
 
 import (
 	"testing"
 )
 
 /*
- * Delimiter tests.
+ * FallbackDelimiter tests.
  */
 
-func Test_Delimiter(t *testing.T) {
+func Test_FallbackDelimiter(t *testing.T) {
 	tests := []struct {
 		name     string
 		line     string
@@ -42,7 +42,7 @@ func Test_Delimiter(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		d := NewDelimiter(256)
+		d := NewFallbackDelimiter(256)
 		events := []string{}
 
 		for _, b := range tt.line {
@@ -64,7 +64,7 @@ func Test_Delimiter(t *testing.T) {
 	}
 }
 
-func TestDelimiter_Vestige(t *testing.T) {
+func TestFallbackDelimiter_Vestige(t *testing.T) {
 	tests := []struct {
 		name           string
 		line           string
@@ -98,7 +98,7 @@ func TestDelimiter_Vestige(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		d := NewDelimiter(256)
+		d := NewFallbackDelimiter(256)
 		for _, c := range tt.line {
 			d.Push(byte(c))
 		}


### PR DESCRIPTION
Dear @otoolep,

as discussed in #25, I was planning to improve the delimiter by using a new method. This one is basically a netstrings implementation, which means that all log messages must be send like this:

`{number of bytes}` + `:` + `{bytes}` + `;`

Luckily, there are libraries in each programming language, which encode the strings on the client site.
The new delimiter brings the following advantages:

- it can separate log messages from each other in a very save way
- it is easy to implement the decoding part
- it does not need to match regexp
- it breaks, when decoding errors happen (will be interesting in the next part of the description)

So lets talk about *backwards compatibility*.

Since the new delimiter breaks, when an decoding errors happen, the `input/collector.go` switches to the old delimiter (now labeled as `fallback_delimiter`), which means that:

- if a client sends logs the old fashion way, the *delimiter* will break instantly and the *fallback* will handle all following logs
- if a client sends logs netstrings like encoded, but for some stupid reason (the encoded bytes contain encoding errors), the *delimiter* will break instantly, when such error happensand the *fallback* will handle all following logs
- if everything is encoded fine, logs will be processed a little bit faster (since regexp matching is not needed anymore).

I think this change is important to make the input process faster and  to make sure there is a more stable way to delimit json.

Next, I will make the pull request for the json/ecma404 support.

I hope you like the changes,

sincerely schlunz. 