### PR TITLE
Update event.go

### DIFF
--- a/input/event.go
+++ b/input/event.go
@@ -21,7 +21,7 @@ func NewEvent() *Event {
 // ReferenceTime returns the reference time of an event.
 func (e *Event) ReferenceTime() time.Time {
 	if e.referenceTime.IsZero() {
-		if e.Parsed == nil {
+		if e.Parsed == nil ||  e.Parsed["timestamp"] == nil {
 			e.referenceTime = e.ReceptionTime
 		} else if refTime, err := time.Parse(time.RFC3339, e.Parsed["timestamp"].(string)); err != nil {
 			e.referenceTime = e.ReceptionTime


### PR DESCRIPTION
It solved some unexpected crashes in my lab

panic: interface conversion: interface {} is nil, not string

goroutine 36 [running]:
github.com/ekanite/ekanite/input.(*Event).ReferenceTime(0xc421a49620, 0xc420489c70, 0xc420489c58, 0xc420489d48)
        /go/src/github.com/ekanite/ekanite/input/event.go:26 +0x1c7
github.com/ekanite/ekanite.(*Engine).Index(0xc420060e00, 0xc421ea6a80, 0x12c, 0x12c, 0x0, 0x0)
        /go/src/github.com/ekanite/ekanite/engine.go:307 +0x185
github.com/ekanite/ekanite.(*Batcher).Start.func1.1()
        /go/src/github.com/ekanite/ekanite/engine.go:67 +0x67
github.com/ekanite/ekanite.(*Batcher).Start.func1(0xc42018b380, 0xc42005b200)
        /go/src/github.com/ekanite/ekanite/engine.go:92 +0x238
created by github.com/ekanite/ekanite.(*Batcher).Start
        /go/src/github.com/ekanite/ekanite/engine.go:99 +0x49
