### PR TITLE
Don't share parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.1 (June 17th 2017)
+- [PR #76](https://github.com/ekanite/ekanite/pull/76): Don't share parsers. Fixes [issue #75](https://github.com/ekanite/ekanite/issues/75).
+
 ## 1.2.0 (January 3rd 2017)
 - [PR #63](https://github.com/ekanite/ekanite/pull/63): Add search duration to HTTP query service output.
 - Cyclomatic complexity improvements.


### PR DESCRIPTION
Each TCP connection, and UDP handler, should have its own parser. Fixes issue #75.