### PR TITLE
Fixed panic in case of error in net.Listen

### DIFF
--- a/input/collector.go
+++ b/input/collector.go
@@ -83,11 +83,12 @@ func (s *TCPCollector) Start(c chan<- *Event) error {
 	} else {
 		ln, err = tls.Listen("tcp", s.iface, s.tlsConfig)
 	}
-	s.addr = ln.Addr()
 
 	if err != nil {
 		return err
 	}
+
+	s.addr = ln.Addr()
 
 	go func() {
 		for {


### PR DESCRIPTION
to reproduce try to listen on a socket already in use

[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x68bdda]

goroutine 1 [running]:
github.com/ekanite/ekanite/input.(*TCPCollector).Start(0xc4200688c0, 0xc420074840, 0x0, 0x0)
        /home/ace/go2/src/github.com/ekanite/ekanite/input/collector.go:86 +0x8a


