### PR TITLE
Type "time" cannot be used as an expvar value

### DIFF
--- a/cmd/ekanited/main.go
+++ b/cmd/ekanited/main.go
@@ -171,8 +171,6 @@ func main() {
 	// Start profiling.
 	startProfile(*cpuProfile, *memProfile)
 
-	stats.Set("launch", time.Now().UTC())
-
 	// Wait forever for signals.
 	waitForSignals()
 


### PR DESCRIPTION
This is stated in the documents.