### PR TITLE
Refactor for multiple parsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ cmd/ekanited/ekanited
 # Folders
 _obj
 _test
+**/.DS_Store
+.idea
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ The browser-based interface also accepts bleve-style queries, identical to those
 ## Diagnostics
 Basic statistics and diagnostics are available. Visit `http://localhost:9951/debug/vars` to retrieve this information. The host and port can be changed via the `-diag` command-line option.
 
+## Building New Parsers
+The architecture now supports the easy implementation of new parsers beyond the stock syslog in 3 easy steps:
+
+1. In `input/parser.go` expand supportedFormats() to capture the additional _standard_ and _name_.
+1. In `parser/`, create the new input format parser using appropriate regex statements.
+    - Ensure that the new parser includes a `timestamp` field compatible with RFC3339, e.g. `2006-01-02T15:04:05Z07:00` 
+1. Back in `input/parser.go`, update NewParser() to properly instantiate the new input format parser.
+
 ## Project Status
 The project is semi-maintained -- contributions in the form of bug reports and pull requests are welcome. Much work remains around performance and scaling, and you can check out [the issues](https://github.com/ekanite/ekanite/issues) for more details.
 

--- a/input/collector.go
+++ b/input/collector.go
@@ -7,7 +7,6 @@ import (
 	"expvar"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"strings"
 	"sync/atomic"
@@ -107,7 +106,6 @@ func (s *TCPCollector) Addr() net.Addr {
 }
 
 func (s *TCPCollector) handleConnection(conn net.Conn, c chan<- *Event) {
-	log.Println("Handling a Connection...")
 	stats.Add("tcpConnections", 1)
 	defer func() {
 		stats.Add("tcpConnections", -1)

--- a/input/collector.go
+++ b/input/collector.go
@@ -7,6 +7,7 @@ import (
 	"expvar"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"strings"
 	"sync/atomic"
@@ -106,6 +107,7 @@ func (s *TCPCollector) Addr() net.Addr {
 }
 
 func (s *TCPCollector) handleConnection(conn net.Conn, c chan<- *Event) {
+	log.Println("Handling a Connection...")
 	stats.Add("tcpConnections", 1)
 	defer func() {
 		stats.Add("tcpConnections", -1)

--- a/input/delimiter_syslog.go
+++ b/input/delimiter_syslog.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	// SYSLOG_DELIMITER indicates the start of a syslog line
-	SYSLOG_DELIMITER = `<[0-9]{1,3}>[0-9]\s`
+	SYSLOG_DELIMITER = `<[0-9]{1,3}>`
 )
 
 var syslogRegex *regexp.Regexp

--- a/input/parser.go
+++ b/input/parser.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	Rfc5424Standard   = "RFC5424"
-	Rfc5424Name       = "syslog"
+	RFC5424Standard   = "RFC5424"
+	RFC5424Name       = "syslog"
 	WatchguardFirebox = "Watchguard"
 	WatchguardName    = "M200"
 )
@@ -17,7 +17,7 @@ type StatsCollector func(key string, delta int64)
 
 type LogParser interface {
 	Parse(raw []byte, result *map[string]interface{})
-	CompileMatcher()
+	Init()
 }
 
 // A Parser parses the raw input as a map with a timestamp field.
@@ -30,13 +30,12 @@ type LogHandler struct {
 }
 
 func supportedFormats() [][]string {
-	return [][]string{{Rfc5424Name, Rfc5424Standard},
+	return [][]string{{RFC5424Name, RFC5424Standard},
 		{WatchguardName, WatchguardFirebox}}
 }
 
 // ValidFormat returns if the given format matches one of the possible formats.
 func ValidFormat(f string) bool {
-
 	l := len(supportedFormats())
 	fmts := supportedFormats()
 
@@ -57,17 +56,15 @@ func NewParser(f string) (*LogHandler, error) {
 
 	var p = &LogHandler{}
 
-	if f == Rfc5424Name {
+	if f == RFC5424Name {
 		p.Parser = &parser.RFC5424{}
 	} else if f == WatchguardName {
 		p.Parser = &parser.Watchguard{}
-	} else {
-		panic(fmt.Sprintf("no supported parser for input format %s", f))
 	}
 
 	log.Printf("input format parser created for %s", f)
 	p.Stats = stats.Add
-	p.Parser.CompileMatcher()
+	p.Parser.Init()
 	return p, nil
 }
 

--- a/input/parser.go
+++ b/input/parser.go
@@ -2,68 +2,80 @@ package input
 
 import (
 	"fmt"
-	"strings"
+	"github.com/ekanite/ekanite/parser"
+	"log"
 )
 
-var (
-	fmtsByStandard = []string{"rfc5424"}
-	fmtsByName     = []string{"syslog"}
+const (
+	Rfc5424Standard   = "RFC5424"
+	Rfc5424Name       = "syslog"
+	WatchguardFirebox = "Watchguard"
+	WatchguardName    = "M200"
 )
 
-// ValidFormat returns if the given format matches one of the possible formats.
-func ValidFormat(format string) bool {
-	for _, f := range append(fmtsByStandard, fmtsByName...) {
-		if f == format {
-			return true
-		}
-	}
-	return false
+type StatsCollector func(key string, delta int64)
+
+type LogParser interface {
+	Parse(raw []byte, result *map[string]interface{})
+	CompileMatcher()
 }
 
 // A Parser parses the raw input as a map with a timestamp field.
-type Parser struct {
-	fmt     string
-	Raw     []byte
-	Result  map[string]interface{}
-	rfc5424 *RFC5424
+type LogHandler struct {
+	Fmt    string
+	Raw    []byte
+	Result map[string]interface{}
+	Parser LogParser
+	Stats func(key string, delta int64)
+}
+
+func supportedFormats() [][]string {
+	return [][]string{{Rfc5424Name, Rfc5424Standard},
+		{WatchguardName, WatchguardFirebox}}
+}
+
+// ValidFormat returns if the given format matches one of the possible formats.
+func ValidFormat(f string) bool {
+
+	l := len(supportedFormats())
+	fmts := supportedFormats()
+
+	for i := 0; i < l; i++ {
+		if fmts[i][0] == f {
+			return true
+		}
+	}
+
+	return false
 }
 
 // NewParser returns a new Parser instance.
-func NewParser(f string) (*Parser, error) {
+func NewParser(f string) (*LogHandler, error) {
 	if !ValidFormat(f) {
-		return nil, fmt.Errorf("%s is not a valid format", f)
+		return nil, fmt.Errorf("%s is not a valid parser format", f)
 	}
 
-	p := &Parser{}
-	p.detectFmt(strings.TrimSpace(strings.ToLower(f)))
-	p.newRFC5424Parser()
+	var p = &LogHandler{}
+
+	if f == Rfc5424Name {
+		p.Parser = &parser.RFC5424{}
+	} else if f == WatchguardName {
+		p.Parser = &parser.Watchguard{}
+	} else {
+		panic(fmt.Sprintf("no supported parser for input format %s", f))
+	}
+
+	log.Printf("input format parser created for %s", f)
+	p.Stats = stats.Add
+	p.Parser.CompileMatcher()
 	return p, nil
 }
 
-// Reads the given format and detects its internal name.
-func (p *Parser) detectFmt(f string) {
-	for i, v := range fmtsByName {
-		if f == v {
-			p.fmt = fmtsByStandard[i]
-			return
-		}
-	}
-	for _, v := range fmtsByStandard {
-		if f == v {
-			p.fmt = v
-			return
-		}
-	}
-	stats.Add("invalidParserFormat", 1)
-	p.fmt = fmtsByStandard[0]
-	return
-}
-
 // Parse the given byte slice.
-func (p *Parser) Parse(b []byte) bool {
+func (p *LogHandler) Parse(b []byte) bool {
 	p.Result = map[string]interface{}{}
 	p.Raw = b
-	p.rfc5424.parse(p.Raw, &p.Result)
+	p.Parser.Parse(p.Raw, &p.Result)
 	if len(p.Result) == 0 {
 		return false
 	}

--- a/parser/rfc5424.go
+++ b/parser/rfc5424.go
@@ -15,7 +15,7 @@ func (p *RFC5424) Stats(callback func(key string, delta int64)) {
 	rfc5424Stats = callback
 }
 
-func (p *RFC5424) CompileMatcher() {
+func (p *RFC5424) Init() {
 	leading := `(?s)`
 	pri := `<([0-9]{1,3})>`
 	ver := `([0-9])`

--- a/parser/rfc5424.go
+++ b/parser/rfc5424.go
@@ -1,21 +1,21 @@
-package input
+package parser
 
 import (
 	"regexp"
 	"strconv"
 )
 
-// RFC5424 represents a parser for RFC5424-compliant log messages
 type RFC5424 struct {
 	matcher *regexp.Regexp
 }
 
-func (p *Parser) newRFC5424Parser() {
-	p.rfc5424 = &RFC5424{}
-	p.rfc5424.compileMatcher()
+var rfc5424Stats = func(key string, delta int64){}
+
+func (p *RFC5424) Stats(callback func(key string, delta int64)) {
+	rfc5424Stats = callback
 }
 
-func (s *RFC5424) compileMatcher() {
+func (p *RFC5424) CompileMatcher() {
 	leading := `(?s)`
 	pri := `<([0-9]{1,3})>`
 	ver := `([0-9])`
@@ -25,16 +25,16 @@ func (s *RFC5424) compileMatcher() {
 	pid := `(-|[0-9]{1,5})`
 	id := `([\w-]+)`
 	msg := `(.+$)`
-	s.matcher = regexp.MustCompile(leading + pri + ver + `\s` + ts + `\s` + host + `\s` + app + `\s` + pid + `\s` + id + `\s` + msg)
+	p.matcher = regexp.MustCompile(leading + pri + ver + `\s` + ts + `\s` + host + `\s` + app + `\s` + pid + `\s` + id + `\s` + msg)
 }
 
-func (s *RFC5424) parse(raw []byte, result *map[string]interface{}) {
-	m := s.matcher.FindStringSubmatch(string(raw))
+func (p *RFC5424) Parse(raw []byte, result *map[string]interface{}) {
+	m := p.matcher.FindStringSubmatch(string(raw))
 	if m == nil || len(m) != 9 {
-		stats.Add("rfc5424Unparsed", 1)
+		rfc5424Stats("rfc5424Unparsed", 1)
 		return
 	}
-	stats.Add("rfc5424Parsed", 1)
+	rfc5424Stats("rfc5424Parsed", 1)
 	pri, _ := strconv.Atoi(m[1])
 	ver, _ := strconv.Atoi(m[2])
 	var pid int

--- a/parser/watchguard.go
+++ b/parser/watchguard.go
@@ -1,0 +1,68 @@
+package parser
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+)
+
+type Watchguard struct {
+	matcher *regexp.Regexp
+}
+
+var watchguardStats = func(key string, delta int64){}
+
+func (p *Watchguard) Stats(callback func(key string, delta int64)) {
+	watchguardStats = callback
+}
+
+//
+// Test at regex-golang.appspot.com/assets/html/index.html
+//
+//([ADFJMNOS][a-z]{2}\s[0-9]{1,2}\s[0-2][0-9]:[0-5]?[0-9]:[0-5]?[0-9])\s([^ ]+)\s([^ ]+)\s\(([^ ]+)\)\s([^ ]+)\smsg_id=\"([0-9\-]+)\"\s([^ ]+)\s([^ ]+)\s([^ ]+)\s(.+$)
+//
+func (p *Watchguard) CompileMatcher() {
+	leading := `(?s)`
+	pri := `<([0-9]{1,3})>`
+	local_dtg := `([ADFJMNOS][a-z]{2}\s[0-9]{1,2}\s[0-2][0-9]:[0-5]?[0-9]:[0-5]?[0-9])`
+	modelName := `([^ ]+)`
+	serialno := `([^ ]+)`
+	utc_dtg := `([^ ]+)`
+	comp := `([^ ]+)`
+	msgId := `([0-9\-]+)`
+	disposition := `([^ ]+)`
+	srcIntf := `([^ ]+)`
+	dstIntf := `([^ ]+)`
+	msg := `(.+$)`
+
+	p.matcher = regexp.MustCompile(leading + pri + local_dtg + `\s` + modelName + `\s` + serialno + `\s\(` +
+		utc_dtg + `\)\s` + comp + `\smsg_id=\"` + msgId + `\"\s` + disposition + `\s` + srcIntf + `\s` +
+		dstIntf + `\s` + msg)
+}
+
+func (p *Watchguard) Parse(raw []byte, result *map[string]interface{}) {
+
+	log.Println(fmt.Sprintf("%s", string(raw)))
+
+	m := p.matcher.FindStringSubmatch(string(raw))
+	if m == nil || len(m) != 12 {
+		watchguardStats("WatchguardM200Unparsed", 1)
+		return
+	}
+	watchguardStats("WatchguardM200Parsed", 1)
+	pri, _ := strconv.Atoi(m[1])
+	*result = map[string]interface{}{
+		"priority":    pri,
+		"local_dtg":   m[2],
+		"model_name":  m[3],
+		"serial_no":   m[4],
+		"timestamp":   m[5],
+		"component":   m[6],
+		"msg_id":      m[7],
+		"disposition": m[8],
+		"src_intf":    m[9],
+		"dst_intf":    m[10],
+		"message":     m[11],
+	}
+}

--- a/parser/watchguard.go
+++ b/parser/watchguard.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"fmt"
-	"log"
 	"regexp"
 	"strconv"
 )
@@ -22,7 +20,7 @@ func (p *Watchguard) Stats(callback func(key string, delta int64)) {
 //
 //([ADFJMNOS][a-z]{2}\s[0-9]{1,2}\s[0-2][0-9]:[0-5]?[0-9]:[0-5]?[0-9])\s([^ ]+)\s([^ ]+)\s\(([^ ]+)\)\s([^ ]+)\smsg_id=\"([0-9\-]+)\"\s([^ ]+)\s([^ ]+)\s([^ ]+)\s(.+$)
 //
-func (p *Watchguard) CompileMatcher() {
+func (p *Watchguard) Init() {
 	leading := `(?s)`
 	pri := `<([0-9]{1,3})>`
 	local_dtg := `([ADFJMNOS][a-z]{2}\s[0-9]{1,2}\s[0-2][0-9]:[0-5]?[0-9]:[0-5]?[0-9])`
@@ -42,9 +40,6 @@ func (p *Watchguard) CompileMatcher() {
 }
 
 func (p *Watchguard) Parse(raw []byte, result *map[string]interface{}) {
-
-	log.Println(fmt.Sprintf("%s", string(raw)))
-
 	m := p.matcher.FindStringSubmatch(string(raw))
 	if m == nil || len(m) != 12 {
 		watchguardStats("WatchguardM200Unparsed", 1)


### PR DESCRIPTION
I'm not sure if ekanite/ekanite is still an active project or not. I needed to process "syslog" records from a Watchguard Firebox. They fail to follow the precise requirements of the RFC5424, like too many big companies these days. 

With this PR, I have refactored the code to support a new package dedicated to hosting various parsers so that the `-input` flag accepts more than just _syslog_.
 
- The vast majority of the work is inside of `input/parser.go` where LogHandler replaces the old Parser type, and there is the introduction of a LogParser interface into the mix.
- In `input/delimiter_syslog` I had to shrink to just the priority, as Watchguard fails to publish a version in their line (just a priority).
- For separation of concerns, the collection of parsers now exist in a new package, and a func callback used to report against the singular stats inside of `collector.go`.
- Finally, I updated the README.md to reflect the 3-step process that can now be used to introduce new parsers into the code.
- All tests pass.


