### PR TITLE
Fix the name/standard alias bug and test

### DIFF
--- a/input/parser.go
+++ b/input/parser.go
@@ -26,7 +26,7 @@ type LogHandler struct {
 	Raw    []byte
 	Result map[string]interface{}
 	Parser LogParser
-	Stats func(key string, delta int64)
+	Stats  func(key string, delta int64)
 }
 
 func supportedFormats() [][]string {
@@ -36,11 +36,8 @@ func supportedFormats() [][]string {
 
 // ValidFormat returns if the given format matches one of the possible formats.
 func ValidFormat(f string) bool {
-	l := len(supportedFormats())
-	fmts := supportedFormats()
-
-	for i := 0; i < l; i++ {
-		if fmts[i][0] == f {
+	for _, v := range supportedFormats() {
+		if v[0] == f || v[1] == f {
 			return true
 		}
 	}
@@ -56,10 +53,12 @@ func NewParser(f string) (*LogHandler, error) {
 
 	var p = &LogHandler{}
 
-	if f == RFC5424Name {
+	if f == RFC5424Name || f == RFC5424Standard {
 		p.Parser = &parser.RFC5424{}
-	} else if f == WatchguardName {
+		p.Fmt = RFC5424Standard
+	} else if f == WatchguardName || f == WatchguardFirebox {
 		p.Parser = &parser.Watchguard{}
+		p.Fmt = WatchguardFirebox
 	}
 
 	log.Printf("input format parser created for %s", f)

--- a/input/parser_test.go
+++ b/input/parser_test.go
@@ -7,23 +7,24 @@ import (
 )
 
 func Test_Formats(t *testing.T) {
-	var p *Parser
+	var p *LogHandler
 	mismatched := func(rtrnd string, intnd string, intndA string) {
 		if intndA != "" {
 			t.Fatalf("Parser format %v does not match the intended format %v.\n", rtrnd, intnd)
 		}
 		t.Fatalf("Parser format %v does not match the intended format %v (same as: %v).\n", rtrnd, intndA, intnd)
 	}
-	for i, f := range fmtsByName {
-		p, _ = NewParser(f)
-		if p.fmt != fmtsByStandard[i] {
-			mismatched(p.fmt, f, fmtsByStandard[i])
+
+	for _, f := range supportedFormats() {
+		p, _ = NewParser(f[0])
+		if p.Fmt != f[1] {
+			mismatched(p.Fmt, f[0], f[1])
 		}
 	}
-	for _, f := range fmtsByStandard {
-		p, _ = NewParser(f)
-		if p.fmt != f {
-			mismatched(p.fmt, f, "")
+	for _, f := range supportedFormats() {
+		p, _ = NewParser(f[1])
+		if p.Fmt != f[1] {
+			mismatched(p.Fmt, f[1], "")
 		}
 	}
 	p, err := NewParser("unknown-format")


### PR DESCRIPTION
In fixing the broken test, I realized I misunderstood the name/standard use as an alias mechanism. This PR fixes that such that you can request _either_ `syslog` _or_ `RFC5424` as an `-input` argument to the program now. Ditto for the WatchGuard addition.

